### PR TITLE
demo

### DIFF
--- a/index.cds
+++ b/index.cds
@@ -1,6 +1,5 @@
 namespace sap.auditlog;
 
-@protocol: 'none'
 service AuditLogService {
 
   action log(event : String, data : LogEntry);
@@ -26,6 +25,7 @@ service AuditLogService {
 
 }
 
+@open
 type LogEntry {
   id        : UUID;
   tenant    : String;

--- a/package.json
+++ b/package.json
@@ -40,6 +40,17 @@
           },
           "[production]": {
             "kind": "audit-log-to-library"
+          },
+          "[mock]": {
+            "kind": "audit-log-to-console",
+            "model": "@cap-js/audit-logging",
+            "service": "sap.auditlog.AuditLogService"
+          },
+          "[demo]": {
+            "kind": "rest",
+            "credentials": { "url": "http://localhost:5005/rest/audit-log" },
+            "model": "@cap-js/audit-logging",
+            "service": "sap.auditlog.AuditLogService"
           }
         },
         "audit-log-to-console": {

--- a/srv/log2console.js
+++ b/srv/log2console.js
@@ -9,7 +9,8 @@ module.exports = class AuditLog2Console extends AuditLogService {
     await super.init()
 
     this.on('*', function (req) {
-      const { event, data } = req
+      // REVISIT: rest adapter currently dispatches requests (instead of invoking the respective operation)
+      const { event, data } = req.data.event ? req.data : req
 
       console.log(`[audit-log] - ${event}:`, data)
     })


### PR DESCRIPTION
in order for the logs to be sent to the second process (i.e., the mock) to be written to that console, the following is needed:
- [this pr](https://github.com/cap-js/audit-logging/pull/5/files)
- [scripts in sample](https://github.com/cap-js/audit-logging-sample/pull/1/files) to start both processes
    1. `npm run mock`
    2. `npm run watch`
- [this runtime fix](https://github.tools.sap/cap/cds/pull/3137/files)
- [this change in @capire/incidents](https://github.tools.sap/cap/incidents-mgmt/pull/35/files) to avoid error (caused by running in dev setup?)