### PR TITLE
fix: audit log registration in case of multiple app services

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+## Version 0.5.1 - tbd
+
+### Fixed
+
+- Falsy early exit during bootstrapping in case a service does not contain personal data
+
 ## Version 0.5.0 - 2023-11-22
 
 ### Added

--- a/cds-plugin.js
+++ b/cds-plugin.js
@@ -17,7 +17,7 @@ cds.on('served', services => {
 
     const relevantEntities = []
     for (const entity of service.entities) if (hasPersonalData(entity)) relevantEntities.push(entity)
-    if (!relevantEntities.length) return
+    if (!relevantEntities.length) continue
 
     for (const entity of relevantEntities) {
       /*

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cap-js/audit-logging",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "CDS plugin providing integration to the SAP Audit Log service as well as out-of-the-box personal data-related audit logging based on annotations.",
   "repository": "cap-js/audit-logging",
   "author": "SAP SE (https://www.sap.com)",


### PR DESCRIPTION
In case of multiple application services, only one has to have the personal data anno.

closes https://github.com/cap-js/audit-logging/issues/66