### PR TITLE
chore: "@sap/cds": ">=7 || ^8.0.0-beta"

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "test-old-db": "npx jest --silent"
   },
   "peerDependencies": {
-    "@sap/cds": ">=7"
+    "@sap/cds": ">=7 || ^8.0.0-beta"
   },
   "devDependencies": {
     "@cap-js/audit-logging": "file:.",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "test-old-db": "npx jest --silent"
   },
   "peerDependencies": {
-    "@sap/cds": "^7"
+    "@sap/cds": ">=7"
   },
   "devDependencies": {
     "@cap-js/audit-logging": "file:.",


### PR DESCRIPTION
Hi @sjvans, I'm currently reviving the `cds add audit-logging` branch and the E2E test is currently failing at `npm i` because we test against `cds#main` (cds 8), but the package requires a peer dependency to `^7`.

I could overwrite in the test, but changing to `>=7` here should be correct anyway, no?