### PR TITLE
feat: allow to pass falsy tenant in oder to log to provider account in multi-tenant scenarios

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+## Version 0.8.0 - tbd
+
+### Added
+
+- Allow to clear the tenant in order to log to provider account in multi-tenant scenarios
+
 ## Version 0.7.0 - tbd
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,13 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
-## Version 0.8.0 - tbd
+## Version 0.8.0 - TBD
 
 ### Added
 
-- Allow to clear the tenant in order to log to provider account in multi-tenant scenarios
+- Allow to specify undefined tenant in order to log to provider account in multi-tenant scenarios
 
-## Version 0.7.0 - tbd
+## Version 0.7.0 - 2024-05-15
 
 ### Added
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cap-js/audit-logging",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "CDS plugin providing integration to the SAP Audit Log service as well as out-of-the-box personal data-related audit logging based on annotations.",
   "repository": "cap-js/audit-logging",
   "author": "SAP SE (https://www.sap.com)",

--- a/srv/log2restv2.js
+++ b/srv/log2restv2.js
@@ -93,6 +93,7 @@ module.exports = class AuditLog2RESTv2 extends AuditLogService {
     } else {
       url = this.options.credentials.url + PATHS.OAUTH2[path]
       data.tenant ??= this._provider //> if request has no tenant, stay in provider account
+      if (data.tenant === '$PROVIDER') data.tenant = this._provider
       headers.authorization = 'Bearer ' + (await this._getToken(data.tenant))
       data.tenant = data.tenant === this._provider ? '$PROVIDER' : '$SUBSCRIBER'
     }

--- a/srv/service.js
+++ b/srv/service.js
@@ -8,7 +8,7 @@ module.exports = class AuditLogService extends Base {
     this.before('*', req => {
       const { tenant, user, timestamp } = cds.context
       req.data.uuid ??= cds.utils.uuid()
-      // allows to clear the tenant in order to log to provider in multi-tenant scenarios
+      // allows to specify undefined tenant in order to log to provider in multi-tenant scenarios
       if (!('tenant' in req.data)) req.data.tenant = tenant
       req.data.user ??= user.id
       req.data.time ??= timestamp

--- a/srv/service.js
+++ b/srv/service.js
@@ -8,7 +8,8 @@ module.exports = class AuditLogService extends Base {
     this.before('*', req => {
       const { tenant, user, timestamp } = cds.context
       req.data.uuid ??= cds.utils.uuid()
-      req.data.tenant ??= tenant
+      // allows to clear the tenant in order to log to provider in multi-tenant scenarios
+      if (!('tenant' in req.data)) req.data.tenant = tenant
       req.data.user ??= user.id
       req.data.time ??= timestamp
     })

--- a/test/api/api.test.js
+++ b/test/api/api.test.js
@@ -123,7 +123,7 @@ describe('AuditLogService API', () => {
       })
     })
 
-    test('tenant can cleared', async () => {
+    test('tenant can be undefined', async () => {
       await cds.tx({ tenant: 'bar' }, async () => {
         const audit = await cds.connect.to('audit-log')
         await audit.log('foo', { uuid: 'baz', tenant: undefined, user: 'baz' })

--- a/test/api/api.test.js
+++ b/test/api/api.test.js
@@ -122,5 +122,17 @@ describe('AuditLogService API', () => {
         time
       })
     })
+
+    test('tenant can cleared', async () => {
+      await cds.tx({ tenant: 'bar' }, async () => {
+        const audit = await cds.connect.to('audit-log')
+        await audit.log('foo', { uuid: 'baz', tenant: undefined, user: 'baz' })
+      })
+      expect(_logs).toContainMatchObject({
+        uuid: 'baz',
+        tenant: undefined,
+        user: 'baz'
+      })
+    })
   })
 })

--- a/test/integration/oauth2.test.js
+++ b/test/integration/oauth2.test.js
@@ -25,4 +25,12 @@ describe('Log to Audit Log Service with oauth2 plan', () => {
     expect(res).toMatchObject({ status: 204 })
     expect(log.output.match(/\$PROVIDER/)).toBeTruthy()
   })
+
+  // NOTE: unoffcial feature
+  test('tenant $PROVIDER is handled correctly', async () => {
+    const data = JSON.stringify({ data: { foo: 'bar' }, tenant: '$PROVIDER' })
+    const res = await POST('/integration/passthrough', { event: 'SecurityEvent', data })
+    expect(res).toMatchObject({ status: 204 })
+    expect(log.output.match(/\$PROVIDER/)).toBeTruthy()
+  })
 })

--- a/test/integration/premium.test.js
+++ b/test/integration/premium.test.js
@@ -25,4 +25,12 @@ describe('Log to Audit Log Service with premium plan', () => {
     expect(res).toMatchObject({ status: 204 })
     expect(log.output.match(/\$PROVIDER/)).toBeTruthy()
   })
+
+  // NOTE: unoffcial feature
+  test('tenant $PROVIDER is handled correctly', async () => {
+    const data = JSON.stringify({ data: { foo: 'bar' }, tenant: '$PROVIDER' })
+    const res = await POST('/integration/passthrough', { event: 'SecurityEvent', data })
+    expect(res).toMatchObject({ status: 204 })
+    expect(log.output.match(/\$PROVIDER/)).toBeTruthy()
+  })
 })


### PR DESCRIPTION
closes https://github.com/cap-js/audit-logging/issues/84

- [x] also allow `$PROVIDER` or the like
- [x] changelog