### PR TITLE
Fix: Wrong subselect being generated

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -130,7 +130,7 @@ const _buildSubSelect = (model, { entity, relative, element, next }, row, dataSu
       {ref: [alisDSE, propDSE]},
       '=',
       {ref: [as, propE]},
-    ])
+    ].concat('and').concat(_addKeysToWhere(keys, row, as)))
     return childCqn
   }
   const targetAlias = _alias(element._target)

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -108,7 +108,7 @@ const _keyColumns = (keys, alias) => {
 
 const _alias = entity => entity.name.replace(`${entity._service.name}.`, '').replace('.', '_')
 
-const _buildSubSelect = (model, { entity, relative, element, next }, row, previousCqn) => {
+const _buildSubSelect = (model, { entity, relative, element, next }, row, dataSubjectEntity, previousCqn) => {
   // relative is a parent or an entity itself
 
   const keys = Object.values(entity.keys)
@@ -118,6 +118,21 @@ const _buildSubSelect = (model, { entity, relative, element, next }, row, previo
 
   const childCqn = SELECT.from({ ref: [entityName], as }).columns(_keyColumns(keys, as))
 
+  //To avoid to much nesting check if data subject + entity have a property annotated as DataSubjectID, use that as on condition
+  if (
+    Object.keys(dataSubjectEntity.elements).some(k => dataSubjectEntity.elements[k]['@PersonalData.FieldSemantics'] === 'DataSubjectID' && !dataSubjectEntity.elements[k].is2one && !dataSubjectEntity.elements[k].is2many) &&
+    Object.keys(entity.elements).some(k => entity.elements[k]['@PersonalData.FieldSemantics'] === 'DataSubjectID' && !entity.elements[k].is2one && !entity.elements[k].is2many)
+  ) {
+    const propDSE = Object.keys(dataSubjectEntity.elements).find(k => dataSubjectEntity.elements[k]['@PersonalData.FieldSemantics'] === 'DataSubjectID' && !dataSubjectEntity.elements[k].is2one && !dataSubjectEntity.elements[k].is2many)
+    const propE = Object.keys(entity.elements).find(k => entity.elements[k]['@PersonalData.FieldSemantics'] === 'DataSubjectID' && !entity.elements[k].is2one && !entity.elements[k].is2many)
+    const alisDSE = _alias(dataSubjectEntity);
+    childCqn.where([
+      {ref: [alisDSE, propDSE]},
+      '=',
+      {ref: [as, propE]},
+    ])
+    return childCqn
+  }
   const targetAlias = _alias(element._target)
   const relativeAlias = _alias(relative)
 
@@ -126,7 +141,7 @@ const _buildSubSelect = (model, { entity, relative, element, next }, row, previo
   if (previousCqn) childCqn.where('exists', previousCqn)
   else childCqn.where(_addKeysToWhere(keys, row, as))
 
-  if (next) return _buildSubSelect(model, next, {}, childCqn)
+  if (next) return _buildSubSelect(model, next, {}, dataSubjectEntity, childCqn)
 
   return childCqn
 }
@@ -138,10 +153,10 @@ const _getDataSubjectIdQuery = ({ dataSubjectEntity, subs }, row, model) => {
   const cqn = SELECT.one
     .from({ ref: [dataSubjectEntity.name], as })
     .columns(_keyColumns(keys, as))
-    .where(['exists', _buildSubSelect(model, subs[0], row)])
+    .where(['exists', _buildSubSelect(model, subs[0], row, dataSubjectEntity)])
 
   // entity reused in different branches => must check all
-  for (let i = 1; i < subs.length; i++) cqn.or(['exists', _buildSubSelect(model, subs[i], row)])
+  for (let i = 1; i < subs.length; i++) cqn.or(['exists', _buildSubSelect(model, subs[i], row, dataSubjectEntity)])
 
   return cqn
 }


### PR DESCRIPTION
With this PR the query generation to look up data subjects is simplified, by checking if the entity has a DataSubjectID element and if so uses that as the on condition referring to the data subject entities DataSubjectID column.

BR,
Marten