### PR TITLE
More performant data subject resolving

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -237,18 +237,28 @@ const addDataSubjectForDetailsEntity = (row, log, req, entity, model) => {
 
 const resolveDataSubjects = async (logs, req) => {
   const map = _getDataSubjectsMap(req)
+  const reqs = [], qtoReqs = new Map(), rowToResMap = new Map();
   for (const each of Object.values(logs)) {
     if (each.data_subject.id instanceof cds.ql.Query) {
       const q = each.data_subject.id
       if (map.has(q)) {
         each.data_subject.id = map.get(q)
       } else {
-        const res = await q
-        map.set(q, res)
-        each.data_subject.id = res
+        if (!qtoReqs.has(q)) {
+          reqs.push(q)
+          qtoReqs.set(q, reqs.length - 1);
+          rowToResMap.set(each, reqs.length - 1);
+        } else {
+          rowToResMap.set(each, qtoReqs.get(q));
+        }
       }
     }
   }
+  const dsIDs = await Promise.all(reqs);
+  rowToResMap.forEach((idx, each) => {
+    map.set(each.data_subject.id, dsIDs[idx]);
+    each.data_subject.id = dsIDs[idx];
+  });
 }
 
 module.exports = {


### PR DESCRIPTION
Hi colleagues,

we can have entities with tens of unique data subject modifications. The current lookup awaits every single one. With the PR the requests are bundled and executed in parallel to reduce response times.

BR,
Marten