### PR TITLE
Fix delete nothing

### DIFF
--- a/lib/modification.js
+++ b/lib/modification.js
@@ -77,6 +77,9 @@ const addDiffToCtx = async function (req) {
 
   // get diff
   let diff = await req.diff()
+  // //Defaulting to an empty object in cases where no diff exists
+  // This happens when a DELETE or UPDATE has a where clause but does not DELETE or UPDATE anything
+  diff ??= {};
   diff = _getDataWithAppliedTransitions(diff, req)
 
   // add keys, if necessary

--- a/test/personal-data/crud.test.js
+++ b/test/personal-data/crud.test.js
@@ -1263,6 +1263,18 @@ describe('personal data audit logging in CRUD', () => {
       })
     })
 
+    test('delete non existing entity does not cause any logs', async () => {
+      const {Pages} = cds.entities('CRUD_1');
+      await cds.delete(Pages).where(`ID = 123456789`);
+
+      expect(_logs).not.toContainMatchObject({
+        object: {
+          type: 'CRUD_1.Pages',
+          id: { ID: 123456789 }
+        }
+      })
+    });
+
     test('delete Pages with integers - flat', async () => {
       await DELETE('/crud-1/Pages(1)', { auth: ALICE })
 


### PR DESCRIPTION
This happens when I have a handler on an entity and inside it trigger a DELETE for an associated entity but the association actually has no data stored. Then the req.diff is undefined causing a 500 error.

The fix sets data to a default empty object so the later handlers of the plugin detect that there is nothing to log.