### PR TITLE
fix: no logs for non-modifying queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 ### Fixed
 
 - Erroneous modification log for non-updated key properties
+- Error during non-modifying queries on database level
 
 ## Version 0.8.1 - 2024-09-13
 

--- a/lib/modification.js
+++ b/lib/modification.js
@@ -76,7 +76,7 @@ const addDiffToCtx = async function (req) {
   if (!_audit.diffs) _audit.diffs = new Map()
 
   // get diff
-  let diff = await req.diff()
+  let diff = (await req.diff()) || {}
   diff = _getDataWithAppliedTransitions(diff, req)
 
   // add keys, if necessary

--- a/test/personal-data/crud.test.js
+++ b/test/personal-data/crud.test.js
@@ -1263,6 +1263,18 @@ describe('personal data audit logging in CRUD', () => {
       })
     })
 
+    test('delete non existing entity does not cause any logs', async () => {
+      const { Pages } = cds.entities('CRUD_1')
+      await cds.delete(Pages).where(`ID = 123456789`)
+
+      expect(_logs).not.toContainMatchObject({
+        object: {
+          type: 'CRUD_1.Pages',
+          id: { ID: 123456789 }
+        }
+      })
+    })
+
     test('delete Pages with integers - flat', async () => {
       await DELETE('/crud-1/Pages(1)', { auth: ALICE })
 


### PR DESCRIPTION
supersedes https://github.com/cap-js/audit-logging/pull/118