### PR TITLE
fix: rewrite to path expression, if alias for relative is already used in subselect to avoid sql error

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -121,7 +121,17 @@ const _buildSubSelect = (model, { entity, relative, element, next }, row, previo
   const targetAlias = _alias(element._target)
   const relativeAlias = _alias(relative)
 
-  childCqn.where(relative._relations[element.name].join(targetAlias, relativeAlias))
+  let w = relative._relations[element.name].join(targetAlias, relativeAlias)
+
+  // REVISIT: rewrite to path expression, if alias for relative is already used in subselect to avoid sql error
+  if (previousCqn?._aliases.has(relativeAlias)) {
+    let t
+    for (const a in entity.associations) if (entity.associations[a].target === relative.name) t = entity.associations[a]
+    if (t && w[0]?.xpr) for (const ele of w[0].xpr) if (ele.ref?.[0] === relativeAlias) ele.ref.splice(0, 1, as, t.name)
+  }
+  childCqn._aliases = new Set(previousCqn ? [...previousCqn._aliases.values(), as] : [as])
+
+  childCqn.where(w)
 
   if (previousCqn) childCqn.where('exists', previousCqn)
   else childCqn.where(_addKeysToWhere(keys, row, as))

--- a/test/personal-data/crud.test.js
+++ b/test/personal-data/crud.test.js
@@ -4,10 +4,10 @@ const { POST: _POST, PATCH: _PATCH, GET: _GET, DELETE: _DELETE, data } = cds.tes
 
 // the persistent outbox adds a delay
 const wait = require('util').promisify(setTimeout)
-const POST = (...args) => _POST(...args).then(async res => (await wait(7), res))
-const PATCH = (...args) => _PATCH(...args).then(async res => (await wait(7), res))
-const GET = (...args) => _GET(...args).then(async res => (await wait(7), res))
-const DELETE = (...args) => _DELETE(...args).then(async res => (await wait(7), res))
+const POST = (...args) => _POST(...args).then(async res => (await wait(11), res))
+const PATCH = (...args) => _PATCH(...args).then(async res => (await wait(11), res))
+const GET = (...args) => _GET(...args).then(async res => (await wait(11), res))
+const DELETE = (...args) => _DELETE(...args).then(async res => (await wait(11), res))
 
 // TODO: @cap-js/sqlite doesn't support structured properties
 // // needed for testing structured properties

--- a/test/personal-data/crud.test.js
+++ b/test/personal-data/crud.test.js
@@ -4,10 +4,11 @@ const { POST: _POST, PATCH: _PATCH, GET: _GET, DELETE: _DELETE, data } = cds.tes
 
 // the persistent outbox adds a delay
 const wait = require('util').promisify(setTimeout)
-const POST = (...args) => _POST(...args).then(async res => (await wait(42), res))
-const PATCH = (...args) => _PATCH(...args).then(async res => (await wait(42), res))
-const GET = (...args) => _GET(...args).then(async res => (await wait(42), res))
-const DELETE = (...args) => _DELETE(...args).then(async res => (await wait(42), res))
+const DELAY = process.env.CI ? 42 : 7
+const POST = (...args) => _POST(...args).then(async res => (await wait(DELAY), res))
+const PATCH = (...args) => _PATCH(...args).then(async res => (await wait(DELAY), res))
+const GET = (...args) => _GET(...args).then(async res => (await wait(DELAY), res))
+const DELETE = (...args) => _DELETE(...args).then(async res => (await wait(DELAY), res))
 
 // TODO: @cap-js/sqlite doesn't support structured properties
 // // needed for testing structured properties

--- a/test/personal-data/crud.test.js
+++ b/test/personal-data/crud.test.js
@@ -4,10 +4,10 @@ const { POST: _POST, PATCH: _PATCH, GET: _GET, DELETE: _DELETE, data } = cds.tes
 
 // the persistent outbox adds a delay
 const wait = require('util').promisify(setTimeout)
-const POST = (...args) => _POST(...args).then(async res => (await wait(11), res))
-const PATCH = (...args) => _PATCH(...args).then(async res => (await wait(11), res))
-const GET = (...args) => _GET(...args).then(async res => (await wait(11), res))
-const DELETE = (...args) => _DELETE(...args).then(async res => (await wait(11), res))
+const POST = (...args) => _POST(...args).then(async res => (await wait(42), res))
+const PATCH = (...args) => _PATCH(...args).then(async res => (await wait(42), res))
+const GET = (...args) => _GET(...args).then(async res => (await wait(42), res))
+const DELETE = (...args) => _DELETE(...args).then(async res => (await wait(42), res))
 
 // TODO: @cap-js/sqlite doesn't support structured properties
 // // needed for testing structured properties


### PR DESCRIPTION
supersedes https://github.com/cap-js/audit-logging/pull/116