### PR TITLE
refactor: Use node:timers/promises/setTimeout

### DIFF
--- a/test/api/api.test.js
+++ b/test/api/api.test.js
@@ -11,7 +11,7 @@ cds.env.requires['audit-log'] = {
   outbox: true
 }
 
-const wait = require('util').promisify(setTimeout)
+const wait = require('node:timers/promises').setTimeout
 
 describe('AuditLogService API', () => {
   let __log, _logs

--- a/test/personal-data/crud.test.js
+++ b/test/personal-data/crud.test.js
@@ -3,7 +3,7 @@ const cds = require('@sap/cds')
 const { POST: _POST, PATCH: _PATCH, GET: _GET, DELETE: _DELETE, data } = cds.test().in(__dirname)
 
 // the persistent outbox adds a delay
-const wait = require('util').promisify(setTimeout)
+const wait = require('node:timers/promises').setTimeout
 const DELAY = process.env.CI ? 42 : 7
 const POST = (...args) => _POST(...args).then(async res => (await wait(DELAY), res))
 const PATCH = (...args) => _PATCH(...args).then(async res => (await wait(DELAY), res))

--- a/test/personal-data/fiori.test.js
+++ b/test/personal-data/fiori.test.js
@@ -3,7 +3,7 @@ const cds = require('@sap/cds')
 const { POST: _POST, PATCH: _PATCH, GET: _GET, DELETE: _DELETE, data } = cds.test().in(__dirname)
 
 // the persistent outbox adds a delay
-const wait = require('util').promisify(setTimeout)
+const wait = require('node:timers/promises').setTimeout
 const POST = (...args) => _POST(...args).then(async res => (await wait(42), res))
 const PATCH = (...args) => _PATCH(...args).then(async res => (await wait(42), res))
 const GET = (...args) => _GET(...args).then(async res => (await wait(42), res))

--- a/test/personal-data/handle.test.js
+++ b/test/personal-data/handle.test.js
@@ -3,7 +3,7 @@ const cds = require('@sap/cds')
 let { GET: _GET } = cds.test().in(__dirname)
 
 // the persistent outbox adds a delay
-const wait = require('util').promisify(setTimeout)
+const wait = require('node:timers/promises').setTimeout
 const GET = (...args) => _GET(...args).then(async res => (await wait(42), res))
 
 cds.env.requires['audit-log'].handle = ['WRITE']


### PR DESCRIPTION
Refactoring to use `require('node:timers/promises').setTimeout` rather than `require('util').promisify(setTimeout)`.

No need to promisify a function as there's a native promise version of that: [Timers Promises API](https://nodejs.org/api/timers.html#timerspromisessettimeoutdelay-value-options)