### PR TITLE
chore: rm legacy cds^7 and sqlite tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         node-version: [22.x, 20.x]
-        cds-version: [8, 9]
+        cds-version: [8]
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node-version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,14 +20,16 @@ jobs:
       fail-fast: false
       matrix:
         node-version: [22.x, 20.x]
+        cds-version: [8]
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
-      - run: npm i -g @sap/cds-dk
+      - run: npm i -g @sap/cds-dk@${{ matrix.cds-version }}
       - run: npm i
+      - run: npm i @sap/cds@${{ matrix.cds-version }}
       - run: cds v
       - run: npm run test
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,16 +20,14 @@ jobs:
       fail-fast: false
       matrix:
         node-version: [22.x, 20.x]
-        cds-version: [8]
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
-      - run: npm i -g @sap/cds-dk@${{ matrix.cds-version }}
+      - run: npm i -g @sap/cds-dk
       - run: npm i
-      - run: npm i @sap/cds@${{ matrix.cds-version }}
       - run: cds v
       - run: npm run test
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         node-version: [22.x, 20.x]
-        cds-version: [8, 7]
+        cds-version: [8, 9]
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node-version }}

--- a/package.json
+++ b/package.json
@@ -14,9 +14,7 @@
   ],
   "scripts": {
     "lint": "npx eslint .",
-    "test": "npm run test-new-db && npm run test-old-db",
-    "test-new-db": "CDS_ENV='better-sqlite' npx jest --silent",
-    "test-old-db": "CDS_ENV='legacy-sqlite' npx jest --silent"
+    "test": "npx jest --silent"
   },
   "peerDependencies": {
     "@sap/cds": ">=8"

--- a/package.json
+++ b/package.json
@@ -25,8 +25,7 @@
     "axios": "^1",
     "eslint": "^9",
     "express": "^4",
-    "jest": "^29",
-    "sqlite3": "^5.1.6"
+    "jest": "^29"
   },
   "cds": {
     "requires": {


### PR DESCRIPTION
Current pipeline and "required" checks need to be adapted, but cds and cds-dk 9 are not yet avaliable. 
