### PR TITLE
fix: bad request publish audit log without data subject id

### DIFF
--- a/test/personal-data/crud.test.js
+++ b/test/personal-data/crud.test.js
@@ -1817,6 +1817,25 @@ describe('personal data audit logging in CRUD', () => {
       expect(_logs).toContainMatchObject({ attributes: [{ name: 'notes', new: '***' }] })
       expect(_logs).toContainMatchObject({ attributes: [{ name: 'notes' }] })
     })
+
+    test("create a comment where DataSubjectID is an association to Customer with no customer referenced", async () => {
+      await POST("/crud-1/Comments", { text: "foo" }, { auth: ALICE });
+      expect(_logs.length).toBe(0);
+    });
+
+    test("create and update a comment where DataSubjectID is an association to Customer with no customer referenced", async () => {
+      const res = await POST( "/crud-1/Comments", { text: "foo" }, { auth: ALICE });
+      expect(res.data.ID).toBeDefined();
+      await PATCH(`/crud-1/Comments(${res.data.ID})`, { text: "bar" }, { auth: ALICE });
+      expect(_logs.length).toBe(0);
+    });
+
+    test("create and delete a comment where DataSubjectID from association to Customer with no customer referenced", async () => {
+      const res = await POST( "/crud-1/Comments", { text: "foo" }, { auth: ALICE });
+      expect(res.data.ID).toBeDefined();
+      await DELETE(`/crud-1/Comments(${res.data.ID})`, { auth: ALICE });
+      expect(_logs.length).toBe(0);
+    });
   })
 
   describe('with renamings', () => {

--- a/test/personal-data/srv/crud-service.cds
+++ b/test/personal-data/srv/crud-service.cds
@@ -61,6 +61,10 @@ service CRUD_1 {
     town     @PersonalData.IsPotentiallyPersonal;
   }
 
+  annotate Comments with @PersonalData   : {EntitySemantics: 'Other'} {
+    customer @PersonalData.FieldSemantics: 'DataSubjectID';
+  }
+
   annotate CustomerStatus with @PersonalData: {EntitySemantics: 'DataSubjectDetails'} {
     description @PersonalData.IsPotentiallySensitive;
     todo        @PersonalData.IsPotentiallyPersonal;


### PR DESCRIPTION
Investigates https://github.com/cap-js/audit-logging/issues/180