### PR TITLE
chore: dependabot cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@ updates:
     schedule:
       interval: "weekly"
     cooldown:
-      default-days: 3
+      default-days: 7
     groups:
       prod-dependencies:
         dependency-type: "production"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,9 @@ updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+    cooldown:
+      default-days: 3
     groups:
       prod-dependencies:
         dependency-type: "production"
@@ -19,9 +21,9 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
     groups:
       github-actions:
         patterns:
           - "*"
-    cooldown:
-      default-days: 7


### PR DESCRIPTION
# Configure Dependabot Cooldown Periods and Update Schedule

### Chore

🔧 Updated the Dependabot configuration to reduce noise by introducing cooldown periods and switching the npm update schedule from daily to weekly.

### Changes

* `.github/dependabot.yml`: 
  - Changed npm package update schedule from `daily` to `weekly`
  - Added a 3-day cooldown (`default-days: 3`) for npm dependency updates
  - Added a 7-day cooldown (`default-days: 7`) for GitHub Actions dependency updates

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.20.47`

- Output Template: [Default Template](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_default_output_template.md)
- Event Trigger: `pull_request.opened`
- Summary Prompt: [Default Prompt](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
- File Content Strategy: Full file content
- Correlation ID: `b3907b19-db05-45ed-a734-ebd3939782bf`
- LLM: `anthropic--claude-4.6-sonnet`
</details>
