### PR TITLE
fix: resolve DataSubject via parent's associations for compo targets

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,1 @@
+npm run format:check

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+## Version 1.2.2 - 2026-06-09
+
+### Fixed
+
+- Resolved server crash when `@PersonalData` annotations are applied to composition targets whose DataSubject is only reachable via the parent entity's sibling association
+
 ## Version 1.2.1 - 2026-05-13
 
 ### Fixed

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -251,9 +251,9 @@ const getDataSubject = (entity, model) => {
     // be always below or always above 'DataSubject' entity in CSN tree
     let dataSubjectInfo = _getDataSubjectUp(entity.name, model, entity);
     if (!dataSubjectInfo) dataSubjectInfo = _getDataSubjectDown(entity.name, entity);
-    entity.set($dataSubject, dataSubjectInfo);
+    entity.set($dataSubject, dataSubjectInfo || false);
   }
-  return entity.own($dataSubject);
+  return entity.own($dataSubject) || undefined;
 };
 
 const _getDataSubjectsMap = (req) => {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -269,8 +269,8 @@ const addDataSubjectForDetailsEntity = (row, log, req, entity, model) => {
   if (!dataSubjectInfo) {
     LOG.warn(
       `No DataSubject entity reachable from '${entity.name}' annotated with @PersonalData.EntitySemantics: '${entity["@PersonalData.EntitySemantics"]}'. ` +
-      `Skipping data-subject enrichment for this entity. ` +
-      `Ensure a path to an entity annotated with @PersonalData.EntitySemantics: 'DataSubject' exists via associations.`
+        `Skipping data-subject enrichment for this entity. ` +
+        `Ensure a path to an entity annotated with @PersonalData.EntitySemantics: 'DataSubject' exists via associations.`
     );
     return;
   }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,4 +1,5 @@
 const cds = require("@sap/cds");
+const LOG = cds.log("audit-log");
 
 const { Relation, exposeRelation, relationHandler } = require("./_relation");
 
@@ -212,6 +213,10 @@ const _getDataSubjectUp = (root, model, entity, prev, next, result) => {
     } else {
       // dfs is a must here
       result = _getDataSubjectUp(root, model, element.parent, me, next || me, result);
+      // If upward traversal dead-ends, try finding the DataSubject downward from the parent entity.
+      // This handles composition targets whose parent reaches a DataSubject via a sibling association
+      // (e.g., Attachments → up to Things → down via owner to Users).
+      if (!result) result = _getDataSubjectDown(root, element.parent, me, next || me);
     }
   }
   return result;
@@ -261,6 +266,14 @@ const _getDataSubjectsMap = (req) => {
 
 const addDataSubjectForDetailsEntity = (row, log, req, entity, model) => {
   const dataSubjectInfo = getDataSubject(entity, model);
+  if (!dataSubjectInfo) {
+    LOG.warn(
+      `No DataSubject entity reachable from '${entity.name}' annotated with @PersonalData.EntitySemantics: '${entity["@PersonalData.EntitySemantics"]}'. ` +
+      `Skipping data-subject enrichment for this entity. ` +
+      `Ensure a path to an entity annotated with @PersonalData.EntitySemantics: 'DataSubject' exists via associations.`
+    );
+    return;
+  }
   const role = dataSubjectInfo.dataSubjectEntity["@PersonalData.DataSubjectRole"];
   log.data_subject.role ??= role;
   log.data_subject.type = dataSubjectInfo.dataSubjectEntity.name;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cap-js/audit-logging",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "CDS plugin providing integration to the SAP Audit Log service as well as out-of-the-box personal data-related audit logging based on annotations.",
   "repository": "cap-js/audit-logging",
   "author": "SAP SE (https://www.sap.com)",

--- a/test/personal-data/crud.test.js
+++ b/test/personal-data/crud.test.js
@@ -2123,7 +2123,11 @@ describe("personal data audit logging in CRUD", () => {
 
       // Setup: create owner and thing (Owners does not compose OwnedThings)
       await POST("/crud-7/Owners", { ID: ownerID, email: "owner@example.com" }, { auth: ALICE });
-      await POST("/crud-7/OwnedThings", { ID: thingID, name: "my-thing", owner_ID: ownerID }, { auth: ALICE });
+      await POST(
+        "/crud-7/OwnedThings",
+        { ID: thingID, name: "my-thing", owner_ID: ownerID },
+        { auth: ALICE }
+      );
 
       _logs = [];
 
@@ -2161,7 +2165,12 @@ describe("personal data audit logging in CRUD", () => {
       await POST("/crud-7/Owners", { ID: ownerID, email: "owner@example.com" }, { auth: ALICE });
       await POST(
         "/crud-7/OwnedThings",
-        { ID: thingID, name: "my-thing", owner_ID: ownerID, attachments: [{ ID: attachmentID, filename: "old.txt", url: "/files/old.txt" }] },
+        {
+          ID: thingID,
+          name: "my-thing",
+          owner_ID: ownerID,
+          attachments: [{ ID: attachmentID, filename: "old.txt", url: "/files/old.txt" }]
+        },
         { auth: ALICE }
       );
 
@@ -2198,7 +2207,12 @@ describe("personal data audit logging in CRUD", () => {
       await POST("/crud-7/Owners", { ID: ownerID, email: "owner@example.com" }, { auth: ALICE });
       await POST(
         "/crud-7/OwnedThings",
-        { ID: thingID, name: "my-thing", owner_ID: ownerID, attachments: [{ ID: attachmentID, filename: "doomed.txt", url: "/files/doomed.txt" }] },
+        {
+          ID: thingID,
+          name: "my-thing",
+          owner_ID: ownerID,
+          attachments: [{ ID: attachmentID, filename: "doomed.txt", url: "/files/doomed.txt" }]
+        },
         { auth: ALICE }
       );
 

--- a/test/personal-data/crud.test.js
+++ b/test/personal-data/crud.test.js
@@ -2115,4 +2115,115 @@ describe("personal data audit logging in CRUD", () => {
       time: expect.any(Date)
     });
   });
+
+  describe("DataSubject resolution for composition target with @PersonalData 'Other'", () => {
+    test("creating an attachment on a composition target resolves data subject via parent's association", async () => {
+      const ownerID = cds.utils.uuid();
+      const thingID = cds.utils.uuid();
+
+      await POST("/crud-7/Owners", {
+        ID: ownerID,
+        email: "owner@example.com",
+        things: [{ ID: thingID, name: "my-thing" }]
+      }, { auth: ALICE });
+
+      _logs = [];
+
+      // Create an attachment on the composition target
+      await POST(
+        `/crud-7/OwnedThings(${thingID})/attachments`,
+        { filename: "hello.txt", url: "/files/hello.txt" },
+        { auth: ALICE }
+      );
+
+      expect(_logs.length).toBeGreaterThanOrEqual(1);
+      expect(_logs).toContainMatchObject({
+        data_subject: {
+          type: "CRUD_7.Owners",
+          role: "Owner",
+          id: { ID: ownerID }
+        },
+        object: {
+          type: "CRUD_7.ThingAttachments",
+          id: { ID: expect.any(String) }
+        },
+        attributes: [
+          { name: "filename", new: "hello.txt" },
+          { name: "url", new: "/files/hello.txt" }
+        ]
+      });
+    });
+
+    test("updating an attachment on a composition target resolves data subject via parent's association", async () => {
+      const ownerID = cds.utils.uuid();
+      const thingID = cds.utils.uuid();
+      const attachmentID = cds.utils.uuid();
+
+      await POST("/crud-7/Owners", {
+        ID: ownerID,
+        email: "owner@example.com",
+        things: [{
+          ID: thingID,
+          name: "my-thing",
+          attachments: [{ ID: attachmentID, filename: "old.txt", url: "/files/old.txt" }]
+        }]
+      }, { auth: ALICE });
+
+      _logs = [];
+
+      await PATCH(
+        `/crud-7/ThingAttachments(${attachmentID})`,
+        { filename: "new.txt" },
+        { auth: ALICE }
+      );
+
+      expect(_logs.length).toBeGreaterThanOrEqual(1);
+      expect(_logs).toContainMatchObject({
+        data_subject: {
+          type: "CRUD_7.Owners",
+          role: "Owner",
+          id: { ID: ownerID }
+        },
+        object: {
+          type: "CRUD_7.ThingAttachments",
+          id: { ID: attachmentID }
+        },
+        attributes: [{ name: "filename", old: "old.txt", new: "new.txt" }]
+      });
+    });
+
+    test("deleting an attachment on a composition target resolves data subject via parent's association", async () => {
+      const ownerID = cds.utils.uuid();
+      const thingID = cds.utils.uuid();
+      const attachmentID = cds.utils.uuid();
+
+      await POST("/crud-7/Owners", {
+        ID: ownerID,
+        email: "owner@example.com",
+        things: [{
+          ID: thingID,
+          name: "my-thing",
+          attachments: [{ ID: attachmentID, filename: "doomed.txt", url: "/files/doomed.txt" }]
+        }]
+      }, { auth: ALICE });
+
+      _logs = [];
+
+      await DELETE(`/crud-7/ThingAttachments(${attachmentID})`, { auth: ALICE });
+
+      expect(_logs.length).toBeGreaterThanOrEqual(1);
+      expect(_logs).toContainMatchObject({
+        data_subject: {
+          type: "CRUD_7.Owners",
+          role: "Owner",
+          id: { ID: ownerID }
+        },
+        object: {
+          type: "CRUD_7.ThingAttachments",
+          id: { ID: attachmentID }
+        },
+        attributes: [{ name: "filename", old: "doomed.txt" }, { name: "url", old: "/files/doomed.txt" }]
+      });
+    });
+  });
 });

--- a/test/personal-data/crud.test.js
+++ b/test/personal-data/crud.test.js
@@ -2121,11 +2121,15 @@ describe("personal data audit logging in CRUD", () => {
       const ownerID = cds.utils.uuid();
       const thingID = cds.utils.uuid();
 
-      await POST("/crud-7/Owners", {
-        ID: ownerID,
-        email: "owner@example.com",
-        things: [{ ID: thingID, name: "my-thing" }]
-      }, { auth: ALICE });
+      await POST(
+        "/crud-7/Owners",
+        {
+          ID: ownerID,
+          email: "owner@example.com",
+          things: [{ ID: thingID, name: "my-thing" }]
+        },
+        { auth: ALICE }
+      );
 
       _logs = [];
 
@@ -2159,15 +2163,21 @@ describe("personal data audit logging in CRUD", () => {
       const thingID = cds.utils.uuid();
       const attachmentID = cds.utils.uuid();
 
-      await POST("/crud-7/Owners", {
-        ID: ownerID,
-        email: "owner@example.com",
-        things: [{
-          ID: thingID,
-          name: "my-thing",
-          attachments: [{ ID: attachmentID, filename: "old.txt", url: "/files/old.txt" }]
-        }]
-      }, { auth: ALICE });
+      await POST(
+        "/crud-7/Owners",
+        {
+          ID: ownerID,
+          email: "owner@example.com",
+          things: [
+            {
+              ID: thingID,
+              name: "my-thing",
+              attachments: [{ ID: attachmentID, filename: "old.txt", url: "/files/old.txt" }]
+            }
+          ]
+        },
+        { auth: ALICE }
+      );
 
       _logs = [];
 
@@ -2197,15 +2207,21 @@ describe("personal data audit logging in CRUD", () => {
       const thingID = cds.utils.uuid();
       const attachmentID = cds.utils.uuid();
 
-      await POST("/crud-7/Owners", {
-        ID: ownerID,
-        email: "owner@example.com",
-        things: [{
-          ID: thingID,
-          name: "my-thing",
-          attachments: [{ ID: attachmentID, filename: "doomed.txt", url: "/files/doomed.txt" }]
-        }]
-      }, { auth: ALICE });
+      await POST(
+        "/crud-7/Owners",
+        {
+          ID: ownerID,
+          email: "owner@example.com",
+          things: [
+            {
+              ID: thingID,
+              name: "my-thing",
+              attachments: [{ ID: attachmentID, filename: "doomed.txt", url: "/files/doomed.txt" }]
+            }
+          ]
+        },
+        { auth: ALICE }
+      );
 
       _logs = [];
 
@@ -2222,7 +2238,10 @@ describe("personal data audit logging in CRUD", () => {
           type: "CRUD_7.ThingAttachments",
           id: { ID: attachmentID }
         },
-        attributes: [{ name: "filename", old: "doomed.txt" }, { name: "url", old: "/files/doomed.txt" }]
+        attributes: [
+          { name: "filename", old: "doomed.txt" },
+          { name: "url", old: "/files/doomed.txt" }
+        ]
       });
     });
   });

--- a/test/personal-data/crud.test.js
+++ b/test/personal-data/crud.test.js
@@ -2121,19 +2121,13 @@ describe("personal data audit logging in CRUD", () => {
       const ownerID = cds.utils.uuid();
       const thingID = cds.utils.uuid();
 
-      await POST(
-        "/crud-7/Owners",
-        {
-          ID: ownerID,
-          email: "owner@example.com",
-          things: [{ ID: thingID, name: "my-thing" }]
-        },
-        { auth: ALICE }
-      );
+      // Setup: create owner and thing (Owners does not compose OwnedThings)
+      await POST("/crud-7/Owners", { ID: ownerID, email: "owner@example.com" }, { auth: ALICE });
+      await POST("/crud-7/OwnedThings", { ID: thingID, name: "my-thing", owner_ID: ownerID }, { auth: ALICE });
 
       _logs = [];
 
-      // Create an attachment on the composition target
+      // Create an attachment on the composition target — this previously crashed
       await POST(
         `/crud-7/OwnedThings(${thingID})/attachments`,
         { filename: "hello.txt", url: "/files/hello.txt" },
@@ -2163,24 +2157,17 @@ describe("personal data audit logging in CRUD", () => {
       const thingID = cds.utils.uuid();
       const attachmentID = cds.utils.uuid();
 
+      // Setup: create owner, thing, and attachment
+      await POST("/crud-7/Owners", { ID: ownerID, email: "owner@example.com" }, { auth: ALICE });
       await POST(
-        "/crud-7/Owners",
-        {
-          ID: ownerID,
-          email: "owner@example.com",
-          things: [
-            {
-              ID: thingID,
-              name: "my-thing",
-              attachments: [{ ID: attachmentID, filename: "old.txt", url: "/files/old.txt" }]
-            }
-          ]
-        },
+        "/crud-7/OwnedThings",
+        { ID: thingID, name: "my-thing", owner_ID: ownerID, attachments: [{ ID: attachmentID, filename: "old.txt", url: "/files/old.txt" }] },
         { auth: ALICE }
       );
 
       _logs = [];
 
+      // Update the attachment
       await PATCH(
         `/crud-7/ThingAttachments(${attachmentID})`,
         { filename: "new.txt" },
@@ -2207,24 +2194,17 @@ describe("personal data audit logging in CRUD", () => {
       const thingID = cds.utils.uuid();
       const attachmentID = cds.utils.uuid();
 
+      // Setup: create owner, thing, and attachment
+      await POST("/crud-7/Owners", { ID: ownerID, email: "owner@example.com" }, { auth: ALICE });
       await POST(
-        "/crud-7/Owners",
-        {
-          ID: ownerID,
-          email: "owner@example.com",
-          things: [
-            {
-              ID: thingID,
-              name: "my-thing",
-              attachments: [{ ID: attachmentID, filename: "doomed.txt", url: "/files/doomed.txt" }]
-            }
-          ]
-        },
+        "/crud-7/OwnedThings",
+        { ID: thingID, name: "my-thing", owner_ID: ownerID, attachments: [{ ID: attachmentID, filename: "doomed.txt", url: "/files/doomed.txt" }] },
         { auth: ALICE }
       );
 
       _logs = [];
 
+      // Delete the attachment
       await DELETE(`/crud-7/ThingAttachments(${attachmentID})`, { auth: ALICE });
 
       expect(_logs.length).toBeGreaterThanOrEqual(1);

--- a/test/personal-data/db/schema.cds
+++ b/test/personal-data/db/schema.cds
@@ -194,3 +194,25 @@ annotate D with @PersonalData: {EntitySemantics: 'Other'} {
   c @PersonalData.FieldSemantics: 'DataSubjectID';
   text @PersonalData.IsPotentiallyPersonal;
 }
+
+// Scenario: composition target with @PersonalData 'Other' where
+// the DataSubject is only reachable via the parent's sibling association
+// (simulates @cap-js/attachments + @PersonalData on the composition target)
+entity Owners : cuid {
+  email   : String;
+  things  : Composition of many OwnedThings
+              on things.owner = $self;
+}
+
+entity OwnedThings : cuid {
+  name        : String;
+  owner       : Association to Owners;
+  attachments : Composition of many ThingAttachments
+                  on attachments.thing = $self;
+}
+
+entity ThingAttachments : cuid {
+  filename : String;
+  url      : String;
+  thing    : Association to OwnedThings;
+}

--- a/test/personal-data/db/schema.cds
+++ b/test/personal-data/db/schema.cds
@@ -199,9 +199,9 @@ annotate D with @PersonalData: {EntitySemantics: 'Other'} {
 // the DataSubject is only reachable via the parent's sibling association
 // (simulates @cap-js/attachments + @PersonalData on the composition target)
 entity Owners : cuid {
-  email   : String;
-  things  : Composition of many OwnedThings
-              on things.owner = $self;
+  email  : String;
+  things : Composition of many OwnedThings
+             on things.owner = $self;
 }
 
 entity OwnedThings : cuid {

--- a/test/personal-data/db/schema.cds
+++ b/test/personal-data/db/schema.cds
@@ -196,12 +196,10 @@ annotate D with @PersonalData: {EntitySemantics: 'Other'} {
 }
 
 // Scenario: composition target with @PersonalData 'Other' where
-// the DataSubject is only reachable via the parent's sibling association
+// the DataSubject is only reachable via the parent's association
 // (simulates @cap-js/attachments + @PersonalData on the composition target)
 entity Owners : cuid {
-  email  : String;
-  things : Composition of many OwnedThings
-             on things.owner = $self;
+  email : String;
 }
 
 entity OwnedThings : cuid {

--- a/test/personal-data/srv/crud-service.cds
+++ b/test/personal-data/srv/crud-service.cds
@@ -226,27 +226,27 @@ service CRUD_6 {
 @path: '/crud-7'
 @requires: 'admin'
 service CRUD_7 {
-  entity Owners          as projection on db.Owners;
-  entity OwnedThings    as projection on db.OwnedThings;
+  entity Owners           as projection on db.Owners;
+  entity OwnedThings      as projection on db.OwnedThings;
   entity ThingAttachments as projection on db.ThingAttachments;
 
   annotate Owners with @PersonalData: {
     EntitySemantics: 'DataSubject',
     DataSubjectRole: 'Owner'
   } {
-    ID    @PersonalData.FieldSemantics: 'DataSubjectID';
+    ID @PersonalData.FieldSemantics: 'DataSubjectID';
     email @PersonalData.IsPotentiallyPersonal;
   };
 
   annotate OwnedThings with @PersonalData: {EntitySemantics: 'Other'} {
     owner @PersonalData.FieldSemantics: 'DataSubjectID';
-    name  @PersonalData.IsPotentiallyPersonal;
+    name @PersonalData.IsPotentiallyPersonal;
   };
 
   // The composition target annotated with 'Other' — DataSubject reachable only
   // via upward composition to OwnedThings, then sideways via owner to Owners.
   annotate ThingAttachments with @PersonalData: {EntitySemantics: 'Other'} {
     filename @PersonalData.IsPotentiallyPersonal;
-    url      @PersonalData.IsPotentiallyPersonal;
+    url @PersonalData.IsPotentiallyPersonal;
   };
 }

--- a/test/personal-data/srv/crud-service.cds
+++ b/test/personal-data/srv/crud-service.cds
@@ -244,7 +244,7 @@ service CRUD_7 {
   };
 
   // The composition target annotated with 'Other' — DataSubject reachable only
-  // via upward composition to OwnedThings, then sideways via owner to Owners.
+  // via upward composition to OwnedThings, then via owner association to Owners.
   annotate ThingAttachments with @PersonalData: {EntitySemantics: 'Other'} {
     filename @PersonalData.IsPotentiallyPersonal;
     url @PersonalData.IsPotentiallyPersonal;

--- a/test/personal-data/srv/crud-service.cds
+++ b/test/personal-data/srv/crud-service.cds
@@ -222,3 +222,31 @@ service CRUD_5 {
 service CRUD_6 {
   entity D as projection on db.D;
 }
+
+@path: '/crud-7'
+@requires: 'admin'
+service CRUD_7 {
+  entity Owners          as projection on db.Owners;
+  entity OwnedThings    as projection on db.OwnedThings;
+  entity ThingAttachments as projection on db.ThingAttachments;
+
+  annotate Owners with @PersonalData: {
+    EntitySemantics: 'DataSubject',
+    DataSubjectRole: 'Owner'
+  } {
+    ID    @PersonalData.FieldSemantics: 'DataSubjectID';
+    email @PersonalData.IsPotentiallyPersonal;
+  };
+
+  annotate OwnedThings with @PersonalData: {EntitySemantics: 'Other'} {
+    owner @PersonalData.FieldSemantics: 'DataSubjectID';
+    name  @PersonalData.IsPotentiallyPersonal;
+  };
+
+  // The composition target annotated with 'Other' — DataSubject reachable only
+  // via upward composition to OwnedThings, then sideways via owner to Owners.
+  annotate ThingAttachments with @PersonalData: {EntitySemantics: 'Other'} {
+    filename @PersonalData.IsPotentiallyPersonal;
+    url      @PersonalData.IsPotentiallyPersonal;
+  };
+}


### PR DESCRIPTION
When `@PersonalData` annotations are applied to a composition target, `getDataSubject()` returned undefined because the upward traversal ended at the parent entity without checking its own associations. The code then returned undefined which crashed the server with a TypeError.