### PR TITLE
poc: additional payload (e.g., "service user") gets propagated

### DIFF
--- a/lib/access.js
+++ b/lib/access.js
@@ -76,7 +76,12 @@ const auditAccess = async function (data, req) {
 
   audit = audit || (await cds.connect.to("audit-log"));
 
-  await Promise.all(accesses.map((access) => audit.log("SensitiveDataRead", access)));
+  await Promise.all(
+    accesses.map((access) => {
+      access.service_user = "bob";
+      return audit.log("SensitiveDataRead", access);
+    })
+  );
 };
 
 module.exports = {

--- a/test/personal-data/crud.test.js
+++ b/test/personal-data/crud.test.js
@@ -62,6 +62,7 @@ describe("personal data audit logging in CRUD", () => {
       expect(_logs.length).toBe(2);
       expect(_logs).toContainMatchObject({
         user: "alice",
+        service_user: "bob",
         object: {
           type: "CRUD_2.CustomerPostalAddress",
           id: { ID: addressID1 }
@@ -79,6 +80,7 @@ describe("personal data audit logging in CRUD", () => {
       });
       expect(_logs).toContainMatchObject({
         user: "alice",
+        service_user: "bob",
         object: {
           type: "CRUD_2.CustomerPostalAddress",
           id: { ID: addressID2 }


### PR DESCRIPTION
# POC: Propagate Additional Payload (e.g., "service user") in Audit Logs

### New Features

✨ **Proof of Concept**: Demonstrates that additional payload fields (such as a `service_user`) can be attached to audit log entries and successfully propagated when logging sensitive data read events.

### Changes

* `lib/access.js`: Updated the `auditAccess` function to attach an additional `service_user` field (hardcoded as `"bob"` for POC purposes) to each access log entry before invoking `audit.log("SensitiveDataRead", access)`.
* `test/personal-data/crud.test.js`: Extended the data access logging test to assert that the `service_user: "bob"` field is present in the resulting audit log entries, validating that the additional payload is correctly propagated.

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.26.0`

- Summary Prompt: [Default Prompt](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
- Event Trigger: `pull_request.opened`
- File Content Strategy: Full file content
- LLM: `anthropic--claude-4.6-sonnet`
- Output Template: [Default Template](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_default_output_template.md)
- Correlation ID: `5772f68b-7cba-4552-8eac-9543195b7a99`
</details>
