### PR TITLE
chore: re-add premium and ng tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,7 +58,7 @@ jobs:
       matrix:
         node-version: [20.x, 22.x]
         cds-version: [latest, 8]
-        als-plan: [standard, oauth2]
+        als-plan: [standard, oauth2, premium, ng]
     steps:
       - name: Run integration tests
         uses: cap-js/audit-logging/.github/actions/integration-tests@main


### PR DESCRIPTION
# Re-add `premium` and `ng` Plans to Integration Test Matrix

### Chore

🔧 Restores the `premium` and `ng` ALS (Audit Log Service) plans to the CI integration test matrix, ensuring they are tested alongside the existing `standard` and `oauth2` plans.

### Changes

* `.github/workflows/test.yml`: Updated the `als-plan` matrix in the `test-integration` job to include `premium` and `ng` in addition to the previously configured `standard` and `oauth2` plans. This results in integration tests running across all four ALS plan types.

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.31.20`

- Output Template: [Default Template](https://github.tools.sap/Code-Change-Intelligence/pr-bot/blob/main/src/services/llm/prompts/summary_default_output_template.md)
- LLM: `anthropic--claude-4.6-sonnet`
- Summary Prompt: [Default Prompt](https://github.tools.sap/Code-Change-Intelligence/pr-bot/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
- File Content Strategy: Full file content
- Event Trigger: `pull_request.opened`
- Correlation ID: `296b8970-ab9b-11f1-90a1-41744f69d3cd`
</details>
